### PR TITLE
Issue52 : パスワードリセット用URL(マジックリンク)送信完了画面

### DIFF
--- a/src/app/auth/reset/password/send/page.tsx
+++ b/src/app/auth/reset/password/send/page.tsx
@@ -30,8 +30,8 @@ export default function AuthResetPasswordSend() {
         />
       </div>
       <div className="mb-4 mt-10 flex flex-col items-center space-y-2">
-        <h2 className="text-2xl font-bold">オブジェを探せゲーム</h2>
-        <p className="text-2xl text-gray-700">パスワード再設定</p>
+        <h1 className="text-2xl font-bold">オブジェを探せゲーム</h1>
+        <h2 className="text-2xl text-gray-700">パスワード再設定</h2>
       </div>
       <div className="flex flex-col items-center justify-around space-y-10 px-10">
         <p className="text-xl">

--- a/src/app/auth/reset/password/send/page.tsx
+++ b/src/app/auth/reset/password/send/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import Image from "next/image";
+import Link from "next/link";
+
+export default function AuthResetPasswordSend() {
+  return (
+    <div className="my-2 mt-11 flex min-h-[90vh] w-full max-w-md flex-col items-center justify-start space-y-4 bg-white sm:px-4 md:mb-5 md:max-w-full">
+      {/* ヘッダー部分 */}
+      <div className="mb-6 flex flex-col items-center space-y-2 text-center">
+        <Image
+          src={"/images/commentLogo.png"}
+          alt="額ロゴの吹き出し"
+          width={120}
+          height={49}
+        />
+        <Image
+          src={"/images/nukaLogo.png"}
+          alt="額のロゴ"
+          width={198}
+          height={64}
+        />
+        <Image src="/images/cross.png" alt="☓アイコン" width={29} height={29} />
+        <Image
+          src="/images/KITimage.png"
+          alt="KITロゴ"
+          width={150}
+          height={75}
+        />
+      </div>
+      <div className="mb-4 mt-10 flex flex-col items-center space-y-2">
+        <h2 className="text-2xl font-bold">オブジェを探せゲーム</h2>
+        <p className="text-2xl text-gray-700">パスワード再設定</p>
+      </div>
+      <div className="flex flex-col items-center justify-around space-y-10 px-10">
+        <p className="text-xl">
+          登録したメールアドレスにパスワードリセットURLを送信しました。
+        </p>
+        <p className="text-xl">
+          メールが届かない場合、迷惑メールフォルダー等もご確認ください。
+        </p>
+        <Button
+          asChild
+          className="h-14 w-full rounded-none bg-[#0094f4] text-2xl"
+        >
+          <Link href={"/auth/login"}>ログイン画面に戻る</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
パスワードリセット用URL(マジックリンク)送信完了画面を実装

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #52 (Issue番号)

## 変更内容
<!-- 変更内容を具体的に記載してください -->
- [x] /auth/reset/password/send画面を追加

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->

### 変更前
未実装につき無し

### 変更後
![image](https://github.com/user-attachments/assets/33b2813b-5266-4c0c-a377-0615448f88fc)


## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [x] ローカル環境で動作確認済み
- [x] 必要なテストを追加/更新済み
- [x] テストが全て成功することを確認済み
- [x] Lintエラーがないことを確認済み

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->

## その他
<!-- その他、補足事項があれば記載してください -->