### PR TITLE
Issue/66: アカウント削除機能の実装(game/settings/account/delete)

### DIFF
--- a/src/app/game/settings/account/delete/page.tsx
+++ b/src/app/game/settings/account/delete/page.tsx
@@ -1,14 +1,31 @@
+"use client";
+
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import NavigationFooter from "@/features/game/NavigationFooter";
-import React from "react";
+import React, { useState } from "react";
 import { ChevronLeft } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { deleteAccount } from "@/features/auth/auth";
+import { useRouter } from 'next/navigation'
 
 export default function GameSettingsAccountDelete() {
   const pageTitle = "設定";
   const pageSubTitle = "アカウント削除";
+  const [error_message, setErrorMessage] = useState("");
+  const [password, setPassword] = useState("");
+  const router = useRouter();
+
+  const deleteButton = async() => {    
+    const result = await deleteAccount(password);
+    if(result.success) {
+      router.push("/game/settings/account/delete/complete");
+    } else {
+      setErrorMessage(result.error_message ?? "アカウント削除に失敗しました")
+    }
+  }
+
 
   return (
     <div className="relative h-full">
@@ -36,10 +53,15 @@ export default function GameSettingsAccountDelete() {
                     placeholder="パスワード"
                     type="password"
                     className="h-10 rounded-none border-black shadow-none"
+                    value={ password }
+                    onChange={(e) => setPassword(e.target.value)}
                 />
             </div>          
           </div>
-          <Button className="mb-4 mt-9 h-14 w-full rounded-none bg-[#ff0000] text-2xl">
+          <div className="text-center text-red-500">
+              { error_message }
+            </div>
+          <Button className="mb-4 mt-9 h-14 w-full rounded-none bg-[#ff0000] text-2xl" onClick={ deleteButton }>
             アカウント削除
           </Button>
         </div>

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -9,7 +9,7 @@ import { EmailAuthProvider } from "firebase/auth/web-extension";
 
 export async function signupWithEmail(email: string, password: string) {
   try {
-    const result = await createUserWithEmailAndPassword(auth, email, password);
+    await createUserWithEmailAndPassword(auth, email, password);
     return { success: true };
   } catch {
     return { success: false, error_message: "アカウント登録に失敗しました" };

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -1,8 +1,11 @@
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
+  deleteUser,
+  reauthenticateWithCredential
 } from "firebase/auth";
 import { auth } from "@/firebase/config";
+import { EmailAuthProvider } from "firebase/auth/web-extension";
 
 export async function signupWithEmail(email: string, password: string) {
   try {
@@ -20,5 +23,28 @@ export async function signinWithEmail(email: string, password: string) {
     return { success: true };
   } catch {
     return { success: false, error_message: "ログインに失敗しました" };
+  }
+}
+
+export async function deleteAccount(password: string) {
+  try {
+    const user = auth.currentUser;
+    const email = auth.currentUser?.email;
+
+    if(user === null || email === null || email === undefined) {
+      return { success: false, error_message: "アカウント削除に失敗しました"};
+    } 
+
+    const credential = EmailAuthProvider.credential(
+      email,
+      password
+    )
+
+    await reauthenticateWithCredential(user, credential);
+    await deleteUser(user);
+
+    return { success: true};
+  } catch {
+    return { success: false, error_message: "アカウント削除に失敗しました"};
   }
 }

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -10,7 +10,6 @@ import { EmailAuthProvider } from "firebase/auth/web-extension";
 export async function signupWithEmail(email: string, password: string) {
   try {
     const result = await createUserWithEmailAndPassword(auth, email, password);
-    console.log(result);
     return { success: true };
   } catch {
     return { success: false, error_message: "アカウント登録に失敗しました" };
@@ -40,7 +39,7 @@ export async function deleteAccount(password: string) {
       password
     )
 
-    await reauthenticateWithCredential(user, credential);
+    await reauthenticateWithCredential(user, credential)
     await deleteUser(user);
 
     return { success: true};


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
アカウント削除機能を実装した。

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #66 (Issue番号)

## 変更内容
<!-- 変更内容を具体的に記載してください -->
- [ ] features/auth/auth.ts にアカウント削除関数を実装した
- [ ] game/settings/account/delete/page.tsx から上記の関数を呼び出す機能を実装した
- [ ] アカウント削除時に再認証をするために、パスワード入力を求め、その値を上記の関数に渡すようにした

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->
アカウント削除失敗時にエラーメッセージが表示されるようにした。

### 変更前
![image](https://github.com/user-attachments/assets/51493a34-e138-406e-b7b2-74e067fabcfe)

### 変更後
![image](https://github.com/user-attachments/assets/665a7c00-ccad-4c62-b4ff-26c649bba7c8)


## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [ ] ローカル環境で動作確認済み
- [ ] 必要なテストを追加/更新済み
- [ ] テストが全て成功することを確認済み
- [ ] Lintエラーがないことを確認済み

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->
本ブランチ(issue/80)はブランチissue/66で追加した再認証用パスワード入力ボックスも含んでいます。
入力ボックスからは、useStateを使用して値を取得しています。
features/auth/auth.ts で不要なコンソールログが発見されたため、合わせて削除しておきました。

## その他
<!-- その他、補足事項があれば記載してください -->