### PR TITLE
Issue/113：外カメラが使用できない場合に、内カメラに自動切替えをする

### DIFF
--- a/src/app/game/scan/page.tsx
+++ b/src/app/game/scan/page.tsx
@@ -7,6 +7,7 @@ import { AuthGuard } from "@/features/auth/authGuard";
 
 export default function GameScan() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [canvasReady, setCanvasReady] = useState(false);
   const router = useRouter();
   const [detectedName, setDetectedName] = useState<string | null>(null);
   const [showPopup, setShowPopup] = useState(false);
@@ -31,7 +32,7 @@ export default function GameScan() {
     return () => {
       if (stopScan) stopScan();
     };
-  }, []);
+  }, [canvasReady]);
 
   const pageTitle = "QRコード読み取り";
   return (
@@ -63,7 +64,13 @@ export default function GameScan() {
             muted
             playsInline
           ></video>
-          <canvas className="hidden" ref={canvasRef}></canvas>
+          <canvas
+            className="hidden"
+            ref={(el) => {
+              canvasRef.current = el;
+              if (el) setCanvasReady(true); // DOMがついたタイミングでフラグを立てる
+            }}>
+          </canvas>
         </div>
 
         <div className="fixed inset-x-0 bottom-0 flex items-center justify-around border bg-white p-4 shadow-md">

--- a/src/app/game/scan/page.tsx
+++ b/src/app/game/scan/page.tsx
@@ -69,8 +69,8 @@ export default function GameScan() {
             ref={(el) => {
               canvasRef.current = el;
               if (el) setCanvasReady(true); // DOMがついたタイミングでフラグを立てる
-            }}>
-          </canvas>
+            }}
+          ></canvas>
         </div>
 
         <div className="fixed inset-x-0 bottom-0 flex items-center justify-around border bg-white p-4 shadow-md">

--- a/src/features/game/scan.ts
+++ b/src/features/game/scan.ts
@@ -13,91 +13,99 @@ export async function ScanQR(
   const MAX_SCREEN_HEIGHT = 480;
 
   if (!canvasRef) return () => {};
+
   const cvs = canvasRef;
   const ctx = cvs.getContext("2d", { willReadFrequently: true });
   if (!ctx) return () => {};
 
+  let stream: MediaStream | null = null;
   try {
-    const stream = await navigator.mediaDevices.getUserMedia({
+    stream = await navigator.mediaDevices.getUserMedia({
       audio: false,
-      video: {
-        facingMode: { exact: "environment" },
-      },
+      video: { facingMode: { exact: "environment" } },
     });
-
-    video.srcObject = stream;
-    await video.play(); // 再生されるまで待つ
-
-    // null値の場合はVGA規格のサイズに合わせて設定
-    const contentWidth =
-      stream.getVideoTracks()[0].getSettings().width || MAX_SCREEN_WIDTH;
-    const contentHeight =
-      stream.getVideoTracks()[0].getSettings().height || MAX_SCREEN_HEIGHT;
-    console.log(contentWidth, contentHeight);
-
-    let intervalId: NodeJS.Timeout | null = null;
-    let animationFrameId: number | null = null;
-
-    const canvasUpdate = () => {
-      cvs.width = contentWidth;
-      cvs.height = contentHeight;
-      ctx.drawImage(video, 0, 0, contentWidth, contentHeight);
-      animationFrameId = requestAnimationFrame(canvasUpdate);
-    };
-
-    const checkImage = async () => {
-      const imageData = ctx.getImageData(0, 0, contentWidth, contentHeight);
-      const code = jsQR(imageData.data, contentWidth, contentHeight);
-
-      if (code) {
-        if (!auth.currentUser) return;
-        const objectsRef = doc(
-          db,
-          "game_progress",
-          auth.currentUser.uid.toString(),
-        );
-
-        // TODO: ハッシュ化 & ソフトコードに修正
-        const objectsName = [
-          "object_1",
-          "object_2",
-          "object_3",
-          "object_4",
-          "object_5",
-          "object_6",
-          "object_7",
-          "object_8",
-          "object_9",
-          "object_10",
-        ];
-
-        for (const objectName of objectsName) {
-          if (code.data === objectName) {
-            await updateDoc(objectsRef, { [objectName]: true });
-            onDetected(objectName);
-            return;
-          }
-        }
-      }
-    };
-
-    canvasUpdate();
-    intervalId = setInterval(checkImage, 300); // 300ms間隔でQRコード読み取り
-    if (!intervalId) {
-      console.error("ERROR: setInterval()");
+  } catch (e) {
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: { facingMode: "user" },
+      });
+      console.warn("environmentカメラが使えないため、userカメラに切り替えました");
+    } catch (err) {
+      console.error("カメラ起動に失敗:", err);
       return () => {};
     }
+  }
 
-    return () => {
-      // アンマウント時の処理
-      if (stream) {
-        stream.getTracks().forEach((track) => track.stop());
+  video.srcObject = stream;
+  await video.play(); // 再生されるまで待つ
+
+  // null値の場合はVGA規格のサイズに合わせて設定
+  const contentWidth =
+    stream.getVideoTracks()[0].getSettings().width || MAX_SCREEN_WIDTH;
+  const contentHeight =
+    stream.getVideoTracks()[0].getSettings().height || MAX_SCREEN_HEIGHT;
+  console.log(contentWidth, contentHeight);
+
+  let intervalId: NodeJS.Timeout | null = null;
+  let animationFrameId: number | null = null;
+
+  const canvasUpdate = () => {
+    cvs.width = contentWidth;
+    cvs.height = contentHeight;
+    ctx.drawImage(video, 0, 0, contentWidth, contentHeight);
+    animationFrameId = requestAnimationFrame(canvasUpdate);
+  };
+
+  const checkImage = async () => {
+    const imageData = ctx.getImageData(0, 0, contentWidth, contentHeight);
+    const code = jsQR(imageData.data, contentWidth, contentHeight);
+
+    if (code) {
+      if (!auth.currentUser) return;
+      const objectsRef = doc(
+        db,
+        "game_progress",
+        auth.currentUser.uid.toString(),
+      );
+
+      // TODO: ハッシュ化 & ソフトコードに修正
+      const objectsName = [
+        "object_1",
+        "object_2",
+        "object_3",
+        "object_4",
+        "object_5",
+        "object_6",
+        "object_7",
+        "object_8",
+        "object_9",
+        "object_10",
+      ];
+
+      for (const objectName of objectsName) {
+        if (code.data === objectName) {
+          await updateDoc(objectsRef, { [objectName]: true });
+          onDetected(objectName);
+          return;
+        }
       }
-      if (intervalId) clearInterval(intervalId);
-      if (animationFrameId) cancelAnimationFrame(animationFrameId);
-    };
-  } catch (error) {
-    console.error("カメラ起動に失敗:", error);
+    }
+  };
+
+  canvasUpdate();
+  intervalId = setInterval(checkImage, 300); // 300ms間隔でQRコード読み取り
+  if (!intervalId) {
+    console.error("ERROR: setInterval()");
     return () => {};
   }
+
+  return () => {
+    // アンマウント時の処理
+    if (stream) {
+      stream.getTracks().forEach((track) => track.stop());
+    }
+    if (intervalId) clearInterval(intervalId);
+    if (animationFrameId) cancelAnimationFrame(animationFrameId);
+  };
 }

--- a/src/features/game/scan.ts
+++ b/src/features/game/scan.ts
@@ -31,7 +31,9 @@ export async function ScanQR(
         audio: false,
         video: { facingMode: "user" },
       });
-      console.warn("environmentカメラが使えないため、userカメラに切り替えました");
+      console.warn(
+        "environmentカメラが使えないため、userカメラに切り替えました",
+      );
     } catch (err) {
       console.error("カメラ起動に失敗:", err);
       return () => {};
@@ -70,15 +72,15 @@ export async function ScanQR(
         auth.currentUser.uid.toString(),
       );
 
-        for (const stampID of stampIDs) {
-          if (code.data === stampID) {
-            await updateDoc(objectsRef, { [stampID]: true });
-            onDetected(stampID);
-            return;
-          }
+      for (const stampID of stampIDs) {
+        if (code.data === stampID) {
+          await updateDoc(objectsRef, { [stampID]: true });
+          onDetected(stampID);
+          return;
         }
       }
-    };
+    }
+  };
 
   canvasUpdate();
   intervalId = setInterval(checkImage, 300); // 300ms間隔でQRコード読み取り

--- a/src/features/game/scan.ts
+++ b/src/features/game/scan.ts
@@ -42,6 +42,7 @@ export async function ScanQR(
   }
 
   video.srcObject = stream;
+  if (!stream) return () => {};
   await video.play(); // 再生されるまで待つ
 
   // null値の場合はVGA規格のサイズに合わせて設定

--- a/src/features/game/scan.ts
+++ b/src/features/game/scan.ts
@@ -33,6 +33,7 @@ export async function ScanQR(
       });
       console.warn(
         "environmentカメラが使えないため、userカメラに切り替えました",
+        e,
       );
     } catch (err) {
       console.error("カメラ起動に失敗:", err);


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
外カメラが使用できないエラーを検出時に、内カメラにアクセスするようにしました。
内カメラも使用できない場合は、console.warnで警告が出ます。（外カメラが使用できない場合も警告は出ます）
## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #113  (Issue番号)

## 変更内容
<!-- 変更内容を具体的に記載してください -->
- [ ] 外カメラが使用できない場合に、内カメラに切り替えるようにした
- [ ] 変更点2

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->

### 変更前

### 変更後

## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [x] ローカル環境で動作確認済み
- [ ] 必要なテストを追加/更新済み
- [ ] テストが全て成功することを確認済み
- [ ] Lintエラーがないことを確認済み

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->
canvasのDOMがついたタイミングでフラグを立て、それを検知後にカメラ起動処理に移るようにしてあります。

## その他
<!-- その他、補足事項があれば記載してください -->